### PR TITLE
Add missing packages required by dataedit app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ django-widget_tweaks
 psycopg2
 sqlalchemy
 Pillow
+bibtexparser
+svn


### PR DESCRIPTION
It seems that dataedit required at least two more extra packages:
- bibtexparser
- svn

to be able to finish the makemigration commands without problems.