### PR TITLE
Add user perm check on backend when deleting a tag

### DIFF
--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -668,6 +668,9 @@ def change_tag(request):
             # requested changes are not valid because of name conflicts
             status = "invalid"
 
+    if not request.user.has_admin_permissions():
+        raise PermissionDenied
+
     elif "submit_delete" in request.POST:
         id = request.POST["tag_id"]
         delete_tag(id)


### PR DESCRIPTION
## Summary of the discussion

Avoid unwanted deletion of OEP-Tags.

## Type of change (CHANGELOG.md)

### Bugs

- Add backend check to avoid unwanted oep database tag delete requests from client [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)

## Workflow checklist

### Automation

Closes #1915 

### PR-Assignee

- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
