### PR TITLE
Update metadata api to sync the tables data model and prevent the metaBuilder to remove and add data unexpectedly 

### DIFF
--- a/api/helper.py
+++ b/api/helper.py
@@ -44,6 +44,8 @@ from api.actions import (
     assert_permission,
     close_cursor,
     close_raw_connection,
+    describe_columns,
+    describe_constraints,
     load_cursor_from_context,
     load_session_from_context,
     open_cursor,
@@ -392,3 +394,166 @@ def get_request_data_dict(request: Request) -> dict:
     if isinstance(request.data, dict):
         return request.data
     raise TypeError(type(request.data))
+
+
+def get_column_description(table_obj: Table):
+    """Return list of column descriptions:
+    [{
+       "name": str,
+       "data_type": str,
+       "is_nullable": bool,
+       "is_pk": bool
+    }]
+
+    """
+
+    def get_datatype_str(column_def):
+        """get single string sql type definition.
+
+        We want the data type definition to be a simple string, e.g. decimal(10, 6)
+        or varchar(128), so we need to combine the various fields
+        (type, numeric_precision, numeric_scale, ...)
+        """
+        # for reverse validation, see also api.parser.parse_type(dt_string)
+        dt = column_def["data_type"].lower()
+        precisions = None
+        if dt.startswith("character"):
+            if dt == "character varying":
+                dt = "varchar"
+            else:
+                dt = "char"
+            precisions = [column_def["character_maximum_length"]]
+        elif dt.endswith(" without time zone"):  # this is the default
+            dt = dt.replace(" without time zone", "")
+        elif re.match("(numeric|decimal)", dt):
+            precisions = [column_def["numeric_precision"], column_def["numeric_scale"]]
+        elif dt == "interval":
+            precisions = [column_def["interval_precision"]]
+        elif re.match(".*int", dt) and re.match(
+            "nextval", column_def.get("column_default") or ""
+        ):
+            # dt = dt.replace('int', 'serial')
+            pass
+        elif dt.startswith("double"):
+            dt = "float"
+        if precisions:  # remove None
+            precisions = [x for x in precisions if x is not None]
+        if precisions:
+            dt += "(%s)" % ", ".join(str(x) for x in precisions)
+        return dt
+
+    def get_pk_fields(constraints):
+        """Get the column names that make up the primary key
+        from the constraints definitions.
+
+        NOTE: Currently, the wizard to create tables only supports
+            single fields primary keys (which is advisable anyways)
+        """
+        pk_fields = []
+        for _name, constraint in constraints.items():
+            if constraint.get("constraint_type") == "PRIMARY KEY":
+                m = re.match(
+                    r"PRIMARY KEY[ ]*\(([^)]+)", constraint.get("definition") or ""
+                )
+                if m:
+                    # "f1, f2" -> ["f1", "f2"]
+                    pk_fields = [x.strip() for x in m.groups()[0].split(",")]
+        return pk_fields
+
+    _columns = describe_columns(table_obj)
+    _constraints = describe_constraints(table_obj)
+    pk_fields = get_pk_fields(_constraints)
+    # order by ordinal_position
+    columns = []
+    for name, col in sorted(
+        _columns.items(), key=lambda kv: int(kv[1]["ordinal_position"])
+    ):
+        columns.append(
+            {
+                "name": name,
+                "data_type": get_datatype_str(col),
+                "is_nullable": col["is_nullable"],
+                "is_pk": name in pk_fields,
+                "unit": None,
+                "description": None,
+            }
+        )
+    return columns
+
+
+def sync_api_metadata_columns(metadata: dict, table_obj: Table) -> dict:
+    """
+    Enforces that the metadata 'fields' exactly match the physical database columns,
+    while preserving human annotations (isAbout, valueReference, etc.).
+    """
+    # 1. Get the physical truths from the database
+    physical_columns = get_column_description(table_obj)
+
+    # Ensure resources array exists safely
+    if not metadata.get("resources"):
+        metadata["resources"] = [{}]
+    resource = metadata["resources"][0]
+
+    if "schema" not in resource:
+        resource["schema"] = {}
+
+    # 2. Extract incoming fields from the API payload
+    incoming_fields = resource["schema"].get("fields", [])
+
+    # Create a fast lookup dict by column name
+    incoming_fields_lookup = {
+        field.get("name"): field
+        for field in incoming_fields
+        if isinstance(field, dict) and field.get("name")
+    }
+
+    updated_fields = []
+
+    # 3. Iterate through physical database columns (The Source of Truth)
+    for db_col in physical_columns:
+        col_name = db_col["name"]
+
+        # Grab the incoming human data if it exists, otherwise empty dict
+        incoming_col = incoming_fields_lookup.get(col_name, {})
+
+        # Ensure 'id' is strictly not nullable
+        is_nullable = db_col["is_nullable"]
+        if col_name == "id":
+            is_nullable = False
+
+        # Start with a copy of the incoming column to preserve all human annotations
+        # (isAbout, valueReference, description, unit, etc.)
+        merged_col = incoming_col.copy()
+
+        # Overwrite physical constraints strictly based on the database
+        merged_col.update(
+            {
+                "name": col_name,
+                "type": db_col["data_type"],
+                "nullable": is_nullable,
+            }
+        )
+
+        # Ensure default keys exist if they weren't in the incoming payload
+        merged_col.setdefault("description", None)
+        merged_col.setdefault("unit", None)
+
+        # --- ARTIFACT SCRUBBER ---
+        # Just in case a user copy-pasted raw JSON from the UI into an API tool,
+        # we scrub the UI-only 'openModalButton' to keep the DB clean.
+        if isinstance(merged_col.get("isAbout"), list):
+            for item in merged_col["isAbout"]:
+                item.pop("openModalButton", None)
+
+        if isinstance(merged_col.get("valueReference"), list):
+            for item in merged_col["valueReference"]:
+                item.pop("openModalButton", None)
+
+        updated_fields.append(merged_col)
+
+    # 4. Overwrite the payload's fields with our perfectly reconciled list
+    # Note: Because we iterate over `physical_columns`, any "phantom" columns
+    # that were in the JSON but not in the DB are automatically dropped!
+    resource["schema"]["fields"] = updated_fields
+
+    return metadata

--- a/api/tests/test_meta.py
+++ b/api/tests/test_meta.py
@@ -19,18 +19,30 @@ class TestPut(APITestCaseWithTable):
         self.api_req("post", path="meta/", data=meta)
         omi_meta_return = self.api_req("get", path="meta/")
 
-        omi_meta = meta
+        # Use deepcopy so we don't mutate the original example constant
+        omi_meta = deepcopy(meta)
 
         # ignore diff in keywords (by setting resulting keywords == input keywords)
         # REASON: the test re-uses the same test table,
         # but does not delete the table tags in between
-        # if we want to synchronize tagsand keywords, the roundtrip would otherwise fail
+        # if we want to synchronize tags and keywords, the roundtrip would otherwise
+        # fail
         omi_meta["resources"][0]["keywords"] = omi_meta["resources"][0].get(
             "keywords", []
         )
         omi_meta_return["resources"][0]["keywords"] = omi_meta["resources"][0][
             "keywords"
         ]
+
+        # ignore diff in schema (by setting resulting schema == input schema)
+        # REASON: The backend now actively synchronizes the metadata 'schema.fields'
+        # with the physical database columns. Since the test table's physical columns
+        # differ from the OEMETADATA_V20_EXAMPLE dummy columns, they will naturally
+        # differ.
+        if "schema" in omi_meta_return["resources"][0]:
+            omi_meta["resources"][0]["schema"] = omi_meta_return["resources"][0][
+                "schema"
+            ]
 
         self.assertDictEqualKeywise(
             omi_meta_return["resources"][0], omi_meta["resources"][0]
@@ -44,10 +56,78 @@ class TestPut(APITestCaseWithTable):
         self.api_req("post", path="meta/", data=meta)
 
     def test_set_meta(self):
-        meta = OEMETADATA_V20_EXAMPLE
+        meta = deepcopy(OEMETADATA_V20_EXAMPLE)
         self.metadata_roundtrip(meta)
 
     def test_complete_metadata(self):
-        meta = OEMETADATA_V20_EXAMPLE
-
+        meta = deepcopy(OEMETADATA_V20_EXAMPLE)
         self.metadata_roundtrip(meta)
+
+    def test_column_sync_preserves_annotations(self):
+        """
+        Verify that the backend sync function correctly enforces physical DB constraints
+        while strictly preserving human-entered ontology annotations (isAbout, etc.).
+        """
+        meta = deepcopy(OEMETADATA_V20_EXAMPLE)
+
+        # 1. Create custom column payload
+        custom_columns = [
+            {
+                "name": "id",
+                "type": "text",  # Intentionally wrong (should sync to bigint...)
+                "nullable": True,  # Intentionally wrong (id should sync to False)
+                "isAbout": [
+                    {
+                        "@id": "http://openenergy-platform.org/ontology/oeo/OEO_00000001",  # noqa: E501
+                        "name": "test identifier",
+                    }
+                ],
+                "valueReference": [
+                    {"@id": "http://example.com/ref", "name": "ref", "value": "val"}
+                ],
+            },
+            {
+                "name": "fake_ghost_column",  # Does not exist in the physical test DB
+                "type": "varchar",
+                "isAbout": [
+                    {
+                        "@id": "http://openenergy-platform.org/ontology/oeo/OEO_00000002",  # noqa: E501
+                        "name": "ghost",
+                    }
+                ],
+            },
+        ]
+
+        meta["resources"][0]["schema"]["fields"] = custom_columns
+
+        # 2. Perform the API POST request
+        self.api_req("post", path="meta/", data=meta)
+
+        # 3. Perform the API GET request to retrieve the synced metadata
+        synced_meta = self.api_req("get", path="meta/")
+        synced_fields = synced_meta["resources"][0]["schema"].get("fields", [])
+
+        # 4. Assertions
+        field_names = [f.get("name") for f in synced_fields]
+
+        # Assertion A: The 'fake_ghost_column' should have been wiped out by the sync
+        self.assertNotIn("fake_ghost_column", field_names)
+
+        # Assertion B: The 'id' column must exist
+        self.assertIn("id", field_names)
+
+        # Extract the reconciled 'id' column
+        id_field = next(f for f in synced_fields if f.get("name") == "id")
+
+        # Assertion C: Physical constraints must be strictly enforced
+        self.assertFalse(id_field.get("nullable"))  # Enforced to False by backend sync
+        self.assertNotEqual(
+            id_field.get("type"), "text"
+        )  # Enforced to match actual DB type (e.g. bigint)
+
+        # Assertion D: Human annotations must be perfectly preserved!
+        self.assertEqual(len(id_field.get("isAbout", [])), 1)
+        self.assertEqual(id_field["isAbout"][0]["name"], "test identifier")
+
+        self.assertEqual(len(id_field.get("valueReference", [])), 1)
+        self.assertEqual(id_field["valueReference"][0]["value"], "val")

--- a/api/views.py
+++ b/api/views.py
@@ -134,6 +134,7 @@ from api.helper import (
     require_delete_permission,
     require_write_permission,
     stream,
+    sync_api_metadata_columns,
     update_tags_from_keywords,
 )
 from api.parser import (
@@ -205,11 +206,15 @@ class TableMetadataAPIView(APIView):
 
         if not error and metadata is not None:
             metadata = try_convert_metadata_to_v2(metadata)
+
+            # Enforce database schema and clean artifacts
+            metadata = sync_api_metadata_columns(metadata, table_obj)
+
+            # Now validate the beautifully cleaned and synced metadata
             metadata, error = try_validate_metadata(metadata)
 
         if metadata is not None:
             # update/sync keywords with tags before saving metadata
-            # TODO make this iter over all resources
             keywords = metadata["resources"][0].get("keywords", []) or []
             metadata["resources"][0]["keywords"] = update_tags_from_keywords(
                 table=table_obj.name, keywords=keywords
@@ -219,8 +224,11 @@ class TableMetadataAPIView(APIView):
             metadata.pop("connection_id", None)
             metadata.pop("cursor_id", None)
 
+            # Save the reconciled metadata to the database
             set_table_metadata(table=table_obj.name, metadata=metadata)
-            return JsonResponse(raw_input)
+
+            # Return the cleaned metadata
+            return JsonResponse(metadata)
         else:
             raise APIError(error)
 

--- a/dataedit/helper.py
+++ b/dataedit/helper.py
@@ -20,7 +20,6 @@ from django.http import HttpRequest, JsonResponse
 import api.parser
 from api.actions import (
     describe_columns,
-    describe_constraints,
     get_column_changes,
     get_constraints_changes,
     set_table_metadata,
@@ -505,91 +504,6 @@ def update_keywords_from_tags(table: Table) -> None:
     metadata["resources"][0]["keywords"] = keywords
 
     set_table_metadata(table=table.name, metadata=metadata)
-
-
-def get_column_description(table_obj: Table):
-    """Return list of column descriptions:
-    [{
-       "name": str,
-       "data_type": str,
-       "is_nullable': bool,
-       "is_pk": bool
-    }]
-
-    """
-
-    def get_datatype_str(column_def):
-        """get single string sql type definition.
-
-        We want the data type definition to be a simple string, e.g. decimal(10, 6)
-        or varchar(128), so we need to combine the various fields
-        (type, numeric_precision, numeric_scale, ...)
-        """
-        # for reverse validation, see also api.parser.parse_type(dt_string)
-        dt = column_def["data_type"].lower()
-        precisions = None
-        if dt.startswith("character"):
-            if dt == "character varying":
-                dt = "varchar"
-            else:
-                dt = "char"
-            precisions = [column_def["character_maximum_length"]]
-        elif dt.endswith(" without time zone"):  # this is the default
-            dt = dt.replace(" without time zone", "")
-        elif re.match("(numeric|decimal)", dt):
-            precisions = [column_def["numeric_precision"], column_def["numeric_scale"]]
-        elif dt == "interval":
-            precisions = [column_def["interval_precision"]]
-        elif re.match(".*int", dt) and re.match(
-            "nextval", column_def.get("column_default") or ""
-        ):
-            # dt = dt.replace('int', 'serial')
-            pass
-        elif dt.startswith("double"):
-            dt = "float"
-        if precisions:  # remove None
-            precisions = [x for x in precisions if x is not None]
-        if precisions:
-            dt += "(%s)" % ", ".join(str(x) for x in precisions)
-        return dt
-
-    def get_pk_fields(constraints):
-        """Get the column names that make up the primary key
-        from the constraints definitions.
-
-        NOTE: Currently, the wizard to create tables only supports
-            single fields primary keys (which is advisable anyways)
-        """
-        pk_fields = []
-        for _name, constraint in constraints.items():
-            if constraint.get("constraint_type") == "PRIMARY KEY":
-                m = re.match(
-                    r"PRIMARY KEY[ ]*\(([^)]+)", constraint.get("definition") or ""
-                )
-                if m:
-                    # "f1, f2" -> ["f1", "f2"]
-                    pk_fields = [x.strip() for x in m.groups()[0].split(",")]
-        return pk_fields
-
-    _columns = describe_columns(table_obj)
-    _constraints = describe_constraints(table_obj)
-    pk_fields = get_pk_fields(_constraints)
-    # order by ordinal_position
-    columns = []
-    for name, col in sorted(
-        _columns.items(), key=lambda kv: int(kv[1]["ordinal_position"])
-    ):
-        columns.append(
-            {
-                "name": name,
-                "data_type": get_datatype_str(col),
-                "is_nullable": col["is_nullable"],
-                "is_pk": name in pk_fields,
-                "unit": None,
-                "description": None,
-            }
-        )
-    return columns
 
 
 def get_cancle_state(request):

--- a/dataedit/static/metaedit/metaedit.js
+++ b/dataedit/static/metaedit/metaedit.js
@@ -172,12 +172,25 @@ window.MetaEdit = function (config) {
     const updatedFields = config.columns.map((col) => {
       const existing = fieldMap.get(col.name) || {};
 
+      // Determine nullable status
+      let isNullable =
+        existing.nullable !== undefined ? existing.nullable : true;
+
+      // Force 'id' column to never be nullable ---
+      if (col.name === "id") {
+        isNullable = false;
+      }
+      // -----------------------------------------------------
+
       return {
+        // Preserves human annotations (isAbout, valueReference) ---
+        ...existing,
+        // --------------------------------------------------------------------
         name: col.name,
         type: col.data_type || existing.type || null,
         description: existing.description ?? null,
         unit: existing.unit ?? null,
-        nullable: existing.nullable !== undefined ? existing.nullable : true,
+        nullable: isNullable, // Use our strictly evaluated nullable flag
       };
     });
 
@@ -224,6 +237,7 @@ window.MetaEdit = function (config) {
     }
 
     fillMissingFromSchema(config.schema.properties, json);
+
     // Fix boundingBox in each resource if needed
     if (Array.isArray(json.resources)) {
       json.resources.forEach((resource) => {
@@ -237,6 +251,34 @@ window.MetaEdit = function (config) {
           if (!resource.spatial.extent) resource.spatial.extent = {};
           resource.spatial.extent.boundingBox = [0, 0, 0, 0]; // fallback valid default
         }
+
+        // Scrub the schema-injected 'openModalButton' ---
+
+        // 1. Scrub from top-level Subject array
+        if (Array.isArray(resource.subject)) {
+          resource.subject.forEach((subItem) => {
+            delete subItem.openModalButton;
+          });
+        }
+
+        // 2. Scrub from Field annotations (isAbout, valueReference)
+        if (resource.schema && Array.isArray(resource.schema.fields)) {
+          resource.schema.fields.forEach((field) => {
+            // Scrub from isAbout
+            if (Array.isArray(field.isAbout)) {
+              field.isAbout.forEach((aboutItem) => {
+                delete aboutItem.openModalButton;
+              });
+            }
+            // Scrub from valueReference
+            if (Array.isArray(field.valueReference)) {
+              field.valueReference.forEach((refItem) => {
+                delete refItem.openModalButton;
+              });
+            }
+          });
+        }
+        // ------------------------------------------------------------
       });
     }
 
@@ -328,7 +370,7 @@ window.MetaEdit = function (config) {
         config.schema = fixSchema(schema[0]);
         config.initialData = fixData(data[0]);
 
-        /*  https://github.com/json-editor/json-editor */
+        /* https://github.com/json-editor/json-editor */
         const options = {
           startval: config.initialData,
           schema: config.schema,
@@ -416,15 +458,14 @@ window.MetaEdit = function (config) {
               jseditor_editor,
               result
             ) {
-             let selected_value = String(result.label)
-                  .replace(/<\/?b>/gi, ""); // Remove <b> tags if present
+              let selected_value = String(result.label).replace(/<\/?b>/gi, ""); // Remove <b> tags if present
 
               let path = String(jseditor_editor.path).replace("name", "@id");
               let path_uri = config.editor.getEditor(path);
-              
+
               // Check if the editor exists before setting value to avoid other errors
               if (path_uri) {
-                  path_uri.setValue(String(result.resource));
+                path_uri.setValue(String(result.resource));
               }
 
               return selected_value;
@@ -433,11 +474,11 @@ window.MetaEdit = function (config) {
           button: {
             openModalAction: function openOeoExtPlugin(jseditor, e) {
               // Perform the HTMX request or any other desired action
-              var targetUrl = config.create_url; 
+              var targetUrl = config.create_url;
 
               if (!targetUrl) {
-                  console.error("MetaEdit Error: config.create_url is missing!");
-                  return;
+                console.error("MetaEdit Error: config.create_url is missing!");
+                return;
               }
               htmx.ajax("GET", targetUrl, {
                 target: ".modal-body",
@@ -540,15 +581,14 @@ window.MetaEdit = function (config) {
               jseditor_editor,
               result
             ) {
-              let selected_value = String(result.label)
-                  .replace(/<\/?b>/gi, "");
+              let selected_value = String(result.label).replace(/<\/?b>/gi, "");
 
               let path = String(jseditor_editor.path).replace("name", "@id");
               let path_uri = config.editor.getEditor(path);
-              
+
               // Check if the editor exists before setting value to avoid other errors
               if (path_uri) {
-                  path_uri.setValue(String(result.resource));
+                path_uri.setValue(String(result.resource));
               }
 
               return selected_value;
@@ -557,13 +597,13 @@ window.MetaEdit = function (config) {
           button: {
             openModalAction: function openOeoExtPlugin(jseditor, e) {
               // Perform the HTMX request or any other desired action
-              var targetUrl = config.create_url; 
+              var targetUrl = config.create_url;
 
               if (!targetUrl) {
-                  console.error("MetaEdit Error: config.create_url is missing!");
-                  return;
+                console.error("MetaEdit Error: config.create_url is missing!");
+                return;
               }
-              
+
               htmx.ajax("GET", targetUrl, {
                 target: ".modal-body",
                 swap: "innerHTML",

--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -66,6 +66,7 @@ from api.actions import (
     table_get_row_count,
 )
 from api.error import APIError
+from api.helper import get_column_description
 from api.utils import table_or_404, table_or_404_from_dict
 from dataedit.forms import GeomViewForm, GraphViewForm, LatLonViewForm
 from dataedit.helper import (
@@ -76,7 +77,6 @@ from dataedit.helper import (
     edit_tag,
     find_tables,
     get_cancle_state,
-    get_column_description,
     get_page,
     merge_field_reviews,
     process_review_data,

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -26,6 +26,10 @@ SPDX-License-Identifier: CC0-1.0
   the german / english synonym if available for an entity
   [(#2277)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2277).
 
+- The metadata api now also syncs the data schema documented in the metadata
+  with the table schema available in the database
+  [(#2290)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2290)
+
 ### Bugs
 
 - Reviewer&Contributor page: calculation of percentage of progress of reviewed
@@ -54,6 +58,11 @@ SPDX-License-Identifier: CC0-1.0
   incomplete due to a messi code refactoring where some code snippets have been
   lost due to merge conflicts in commits that are not pushed to remote.
   [(#2289)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2289)
+
+- Fixed a bug in the oemetaBuilder tool that removed `isAbout` and
+  `valueReference` entries and added unwanted properties when the users submits
+  the Editor form
+  [(#2290)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2290)
 
 ## Documentation updates
 


### PR DESCRIPTION
## Summary of the discussion

- Fix a bug that removed isAbout and valueReference entires when submitting them usign the oemetaBuilder editing tool
- Remove unwanted additional data that was added to the metadata json document by the oemetaBuilder tool 
- Harmonize sync of oemetadata documents and database table schema

## Type of change (CHANGELOG.md)

### Features

- The metadata api now also syncs the data schema documented in the metadata with the table schema available in the database
  [(#2290)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2290)

### Bugs

- Fixed a bug in the oemetaBuilder tool that removed `isAbout` and `valueReference` entries and added unwanted properties when the users submits the Editor form
  [(#2290)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2290)


## Workflow checklist

### Automation

Closes #2284

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
