### PR TITLE
Make fetch calls relative (fixes #2292)

### DIFF
--- a/dataedit/static/metaedit/metaedit.js
+++ b/dataedit/static/metaedit/metaedit.js
@@ -426,8 +426,7 @@ window.MetaEdit = function (config) {
         window.JSONEditor.defaults.callbacks = {
           autocomplete: {
             search_name: function search(jseditor_editor, input) {
-              var url =
-                "https://openenergyplatform.org/api/oeo-search?query=" + input;
+              var url = "/api/oeo-search?query=" + input;
 
               return new Promise(function (resolve) {
                 fetch(url, {
@@ -549,8 +548,7 @@ window.MetaEdit = function (config) {
         window.JSONEditor.defaults.callbacks = {
           autocomplete: {
             search_name: function search(jseditor_editor, input) {
-              var url =
-                "https://openenergyplatform.org/api/oeo-search?query=" + input;
+              var url = "/api/oeo-search?query=" + input;
 
               return new Promise(function (resolve) {
                 fetch(url, {

--- a/oeo_ext/templates/oeo_ext/partials/unit_element.html
+++ b/oeo_ext/templates/oeo_ext/partials/unit_element.html
@@ -48,7 +48,7 @@
       if (query.length > 0) {
         // use static path here to always use the open (data seeded) endpoint for
         // all (local, deployed) client executions
-        fetch(`https://openenergyplatform.org/api/oeo-search?query=${query}`, {
+        fetch(`/api/oeo-search?query=${query}`, {
           mode: "cors",
         })
           .then((response) => response.json())

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -13,6 +13,9 @@ SPDX-License-Identifier: CC0-1.0
 - Create tables_sections.html, delete user_partial_tables
   [(#2248)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2248)
 
+- Update fetch call for oeo-search api to be relative
+  [(#2293)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2293)
+
 ### Features
 
 - Build search field to search in the user's tables


### PR DESCRIPTION
## Summary of the discussion
Update the fetch calls for oeo-search to be relative to page domain. This is relevant for instances which are not the original openenergyplatform and might use a different or extended ontology.

## Type of change (CHANGELOG.md)

### Changes

- Update fetch call for oeo-search api to be relative
  [(#2293)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2293)

## Workflow checklist

### Automation

Closes #2292

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
